### PR TITLE
Initial work on the JSON payload for the salesforce webhook

### DIFF
--- a/web/modules/custom/ilr_registrations/ilr_registrations.module
+++ b/web/modules/custom/ilr_registrations/ilr_registrations.module
@@ -174,6 +174,35 @@ function ilr_registrations_salesforce_mapped_object_presave(EntityInterface $sf_
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_presave().
+ *
+ * Store salesforce id data with class order items.
+ */
+function erf_commerce_commerce_order_item_presave(EntityInterface $order_item) {
+  if ($order_item->bundle() !== 'class') {
+    return;
+  }
+
+  $sf_mapping_storage = \Drupal::service('entity_type.manager')->getStorage('salesforce_mapped_object');
+  $class_product_variation = $order_item->getPurchasedEntity();
+  $course_product = $class_product_variation->getProduct();
+
+  $sf_variation_mapped_objects = $sf_mapping_storage->loadByEntity($class_product_variation);
+
+  if (!empty($sf_variation_mapped_objects)) {
+    $sf_variation_mapped_object = reset($sf_variation_mapped_objects);
+    $order_item->setData('sf_class_id', $sf_variation_mapped_object->sfid());
+  }
+
+  $sf_product_mapped_objects = $sf_mapping_storage->loadByEntity($course_product);
+
+  if (!empty($sf_product_mapped_objects)) {
+    $sf_product_mapped_object = reset($sf_product_mapped_objects);
+    $order_item->setData('sf_course_id', $sf_product_mapped_object->sfid());
+  }
+}
+
+/**
  * Implements hook_entity_bundle_create().
  */
 function ilr_registrations_entity_bundle_create($entity_type_id, $bundle) {

--- a/web/modules/custom/ilr_registrations/ilr_registrations.routing.yml
+++ b/web/modules/custom/ilr_registrations/ilr_registrations.routing.yml
@@ -6,3 +6,11 @@ ilr_registrations.sf_id_redirect:
   requirements:
     _permission: 'view commerce_product'
     salesforce_id: '[a-zA-Z0-9]{15}|[a-zA-Z0-9]{18}'
+
+ilr_registrations.serialized_order_controller_load:
+  path: '/admin/commerce/orders/{commerce_order}/serialized'
+  defaults:
+    _controller: '\Drupal\ilr_registrations\Controller\SerializedOrderController::load'
+    _title: 'Serialized Commerce Order'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/ilr_registrations/ilr_registrations.services.yml
+++ b/web/modules/custom/ilr_registrations/ilr_registrations.services.yml
@@ -2,9 +2,12 @@ services:
   ilr_registrations_commerce_event_subscriber:
     class: Drupal\ilr_registrations\EventSubscriber\CommerceEventSubscriber
     tags:
-    - { name: event_subscriber }
+      - { name: event_subscriber }
   ilr_registrations_salesforce_event_subscriber:
     class: Drupal\ilr_registrations\EventSubscriber\SalesforceEventSubscriber
     arguments: []
     tags:
       - { name: event_subscriber }
+  ilr_registrations.serialized_order:
+    class: Drupal\ilr_registrations\SerializedOrderManager
+    arguments: ['@entity.manager']

--- a/web/modules/custom/ilr_registrations/src/Controller/SerializedOrderController.php
+++ b/web/modules/custom/ilr_registrations/src/Controller/SerializedOrderController.php
@@ -4,7 +4,7 @@ namespace Drupal\ilr_registrations\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\ilr_registrations\SerializedOrderManagerInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -13,20 +13,18 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  */
 class SerializedOrderController extends ControllerBase {
 
-  const POS_ID = 'register.ilr.cornell.edu';
-
   /**
-   * Drupal\Core\Entity\EntityManagerInterface definition.
+   * Drupal\ilr_registrations\SerializedOrderManagerInterface definition.
    *
-   * @var \Drupal\Core\Entity\EntityManagerInterface
+   * @var \Drupal\ilr_registrations\SerializedOrderManagerInterface
    */
-  protected $entityManager;
+  protected $serializedOrderManager;
 
   /**
    * Constructs a new SerializedOrderController object.
    */
-  public function __construct(EntityManagerInterface $entity_manager) {
-    $this->entityManager = $entity_manager;
+  public function __construct(SerializedOrderManagerInterface $serialized_order_manager) {
+    $this->serializedOrderManager = $serialized_order_manager;
   }
 
   /**
@@ -34,139 +32,23 @@ class SerializedOrderController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity.manager')
+      $container->get('ilr_registrations.serialized_order')
     );
   }
 
   /**
-   * Hello.
+   * Get a full serialized order object and return as JSON.
    *
    * @todo Refactor payment objects to allow for payment types other than credit
    * card.
    * @todo Verify hardcoded fields on the billing profile (e.g.
    * field_organization and the name fields).
    *
-   * @return string Return Hello string.
+   * @return JsonResponse A full serialized order object.
    */
   public function load(OrderInterface $commerce_order) {
-    $order = $commerce_order;
-    $items = $order->getItems();
-    $customer = $order->getCustomer();
-    $billing_profile = $order->getBillingProfile();
-    $payments = $this->entityManager->getStorage('commerce_payment')->loadByProperties([
-      'order_id' => $order->id(),
-    ]);
-    $payment = reset($payments);
-    $payment_gateway = $payment->getPaymentGateway();
-
-    // @todo Deal with remote transaction retrieval failure.
-    $transaction = $payment_gateway->getPlugin()->getTransaction($payment->getRemoteId());
-
-    $promotion_storage = $this->entityManager->getStorage('commerce_promotion');
-    $sf_mapping_storage = $this->entityManager->getStorage('salesforce_mapped_object');
-
-    $response = [
-      "point_of_sale" => $this::POS_ID,
-      "order_id" => $order->id(),
-      "payments" => [
-        [
-          "payment_type" => $payment_gateway->getPluginId(), //"freedompay_cc",
-          "payment_id" => $payment->id(),
-          "amount" => (float) $payment->getAmount()->getNumber(),
-          "transaction_id" => $payment->getRemoteId(),
-          "transaction_data" => $transaction,
-        ]
-      ],
-      "customer" => [
-        "contact_sfid" => null,
-        "user_email" => $billing_profile->uid->entity->mail->value,
-        "billing_email" => $billing_profile->field_email->value,
-        "first_name" => $billing_profile->field_first_name->value,
-        "last_name" => $billing_profile->field_last_name->value,
-        "company" => $billing_profile->field_organization->value,
-        "job_title" => $billing_profile->field_job_title->value,
-        "phone" => $billing_profile->field_phone->value,
-        "additional_fields" => [], // @todo
-      ],
-      "order_total" => (float) $order->getTotalPaid()->getNumber(),
-      "items" => [],
-      "discounts" => [], // @todo These might be full order adjustments.
-    ];
-
-    foreach ($items as $item) {
-      $discounts = [];
-      $item_adjustments = $item->getAdjustments();
-
-      foreach ($item_adjustments as $item_adjustment) {
-        $promotions = $promotion_storage->loadByProperties([
-          'promotion_id' => $item_adjustment->getSourceId(),
-        ]);
-
-        if (count($promotions)) {
-          foreach ($promotions as $promotion) {
-            $sf_promo_mapped_objects = $sf_mapping_storage->loadByEntity($promotion);
-            $sf_promo_mapped_object = reset($sf_promo_mapped_objects);
-
-            $discount = [
-              "sfid" => $sf_promo_mapped_object->sfid(),
-              "code" => $promotion->label(),
-              "type" => $item_adjustment->getPercentage() ? 'percentage' : 'amount',
-              "amount" => (float) $item_adjustment->getAmount()->getNumber(),
-              "percentage" => (float) $item_adjustment->getPercentage(),
-            ];
-
-            $discounts[] = $discount;
-          }
-        }
-      }
-
-      $participants = [];
-      $registration = $this->entityManager->getStorage('registration')->loadByProperties([
-        'commerce_order_item_id' => $item->id(),
-      ]);
-
-      if ($registration) {
-        $registration = reset($registration);
-        foreach ($registration->participants as $participant) {
-          $participants[] = [
-            "contact_sfid" => null,
-            'email' => $participant->entity->mail->value,
-            "first_name" => $participant->entity->field_first_name->value,
-            "last_name" => $participant->entity->field_last_name->value,
-            'additional_fields' => [], // @todo
-          ];
-        }
-
-        $class_product_variation = $item->getPurchasedEntity();
-        $course_product = $class_product_variation->getProduct();
-
-        $sf_variation_mapped_objects = $sf_mapping_storage->loadByEntity($class_product_variation);
-        $sf_variation_mapped_object = reset($sf_variation_mapped_objects);
-
-        $sf_product_mapped_objects = $sf_mapping_storage->loadByEntity($course_product);
-        $sf_product_mapped_object = reset($sf_product_mapped_objects);
-      }
-
-      $response['items'][] = [
-        'name' => $item->getTitle(),
-        "discounts" => $discounts,
-        "price" => (float) $item->getUnitPrice()->getNumber(),
-        "discounted_price" => (float) $item->getAdjustedUnitPrice()->getNumber(),
-        "quantity" => (int) $item->getQuantity(),
-        "total" => (float) $item->getTotalPrice()->getNumber(),
-        "discounted_total" => (float) $item->getAdjustedTotalPrice()->getNumber(),
-        "registration" => [
-          "description" => "For example, a single course with 1+ participants.",
-          "product_type" => "Open Enrollment",
-          "course_id" => $sf_product_mapped_object->sfid(),
-          "class_id" => $sf_variation_mapped_object->sfid(),
-          "additional_fields" => [],
-          "participants" => $participants,
-        ]
-      ];
-    }
-
-    return new JsonResponse($response);
+    $serializable_order = $this->serializedOrderManager->getObjectForOrder($commerce_order);
+    return new JsonResponse($serializable_order);
   }
 
 }

--- a/web/modules/custom/ilr_registrations/src/Controller/SerializedOrderController.php
+++ b/web/modules/custom/ilr_registrations/src/Controller/SerializedOrderController.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Drupal\ilr_registrations\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\commerce_order\Entity\OrderInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Class SerializedOrderController.
+ */
+class SerializedOrderController extends ControllerBase {
+
+  const POS_ID = 'register.ilr.cornell.edu';
+
+  /**
+   * Drupal\Core\Entity\EntityManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * Constructs a new SerializedOrderController object.
+   */
+  public function __construct(EntityManagerInterface $entity_manager) {
+    $this->entityManager = $entity_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.manager')
+    );
+  }
+
+  /**
+   * Hello.
+   *
+   * @todo Refactor payment objects to allow for payment types other than credit
+   * card.
+   * @todo Verify hardcoded fields on the billing profile (e.g.
+   * field_organization and the name fields).
+   *
+   * @return string Return Hello string.
+   */
+  public function load(OrderInterface $commerce_order) {
+    $order = $commerce_order;
+    $items = $order->getItems();
+    $customer = $order->getCustomer();
+    $billing_profile = $order->getBillingProfile();
+    $payments = $this->entityManager->getStorage('commerce_payment')->loadByProperties([
+      'order_id' => $order->id(),
+    ]);
+    $payment = reset($payments);
+    $payment_gateway = $payment->getPaymentGateway();
+
+    // @todo Deal with remote transaction retrieval failure.
+    $transaction = $payment_gateway->getPlugin()->getTransaction($payment->getRemoteId());
+
+    $promotion_storage = $this->entityManager->getStorage('commerce_promotion');
+    $sf_mapping_storage = $this->entityManager->getStorage('salesforce_mapped_object');
+
+    $response = [
+      "point_of_sale" => $this::POS_ID,
+      "order_id" => $order->id(),
+      "payments" => [
+        [
+          "payment_type" => $payment_gateway->getPluginId(), //"freedompay_cc",
+          "payment_id" => $payment->id(),
+          "amount" => (float) $payment->getAmount()->getNumber(),
+          "transaction_id" => $payment->getRemoteId(),
+          "transaction_data" => $transaction,
+        ]
+      ],
+      "customer" => [
+        "contact_sfid" => null,
+        "user_email" => $billing_profile->uid->entity->mail->value,
+        "billing_email" => $billing_profile->field_email->value,
+        "first_name" => $billing_profile->field_first_name->value,
+        "last_name" => $billing_profile->field_last_name->value,
+        "company" => $billing_profile->field_organization->value,
+        "job_title" => $billing_profile->field_job_title->value,
+        "phone" => $billing_profile->field_phone->value,
+        "additional_fields" => [], // @todo
+      ],
+      "order_total" => (float) $order->getTotalPaid()->getNumber(),
+      "items" => [],
+      "discounts" => [], // @todo These might be full order adjustments.
+    ];
+
+    foreach ($items as $item) {
+      $discounts = [];
+      $item_adjustments = $item->getAdjustments();
+
+      foreach ($item_adjustments as $item_adjustment) {
+        $promotions = $promotion_storage->loadByProperties([
+          'promotion_id' => $item_adjustment->getSourceId(),
+        ]);
+
+        if (count($promotions)) {
+          foreach ($promotions as $promotion) {
+            $sf_promo_mapped_objects = $sf_mapping_storage->loadByEntity($promotion);
+            $sf_promo_mapped_object = reset($sf_promo_mapped_objects);
+
+            $discount = [
+              "sfid" => $sf_promo_mapped_object->sfid(),
+              "code" => $promotion->label(),
+              "type" => $item_adjustment->getPercentage() ? 'percentage' : 'amount',
+              "amount" => (float) $item_adjustment->getAmount()->getNumber(),
+              "percentage" => (float) $item_adjustment->getPercentage(),
+            ];
+
+            $discounts[] = $discount;
+          }
+        }
+      }
+
+      $participants = [];
+      $registration = $this->entityManager->getStorage('registration')->loadByProperties([
+        'commerce_order_item_id' => $item->id(),
+      ]);
+
+      if ($registration) {
+        $registration = reset($registration);
+        foreach ($registration->participants as $participant) {
+          $participants[] = [
+            "contact_sfid" => null,
+            'email' => $participant->entity->mail->value,
+            "first_name" => $participant->entity->field_first_name->value,
+            "last_name" => $participant->entity->field_last_name->value,
+            'additional_fields' => [], // @todo
+          ];
+        }
+
+        $class_product_variation = $item->getPurchasedEntity();
+        $course_product = $class_product_variation->getProduct();
+
+        $sf_variation_mapped_objects = $sf_mapping_storage->loadByEntity($class_product_variation);
+        $sf_variation_mapped_object = reset($sf_variation_mapped_objects);
+
+        $sf_product_mapped_objects = $sf_mapping_storage->loadByEntity($course_product);
+        $sf_product_mapped_object = reset($sf_product_mapped_objects);
+      }
+
+      $response['items'][] = [
+        'name' => $item->getTitle(),
+        "discounts" => $discounts,
+        "price" => (float) $item->getUnitPrice()->getNumber(),
+        "discounted_price" => (float) $item->getAdjustedUnitPrice()->getNumber(),
+        "quantity" => (int) $item->getQuantity(),
+        "total" => (float) $item->getTotalPrice()->getNumber(),
+        "discounted_total" => (float) $item->getAdjustedTotalPrice()->getNumber(),
+        "registration" => [
+          "description" => "For example, a single course with 1+ participants.",
+          "product_type" => "Open Enrollment",
+          "course_id" => $sf_product_mapped_object->sfid(),
+          "class_id" => $sf_variation_mapped_object->sfid(),
+          "additional_fields" => [],
+          "participants" => $participants,
+        ]
+      ];
+    }
+
+    return new JsonResponse($response);
+  }
+
+}

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
@@ -45,7 +45,6 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
     // @todo Deal with possible remote transaction retrieval failure.
     $transaction = $payment_gateway->getPlugin()->getTransaction($payment->getRemoteId());
 
-
     $response = [
       "point_of_sale" => $payment_gateway->id(),
       "order_id" => $order->id(),
@@ -59,7 +58,7 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
         ]
       ],
       "customer" => [
-        "contact_sfid" => null,
+        "contact_sfid" => null, // @todo Lookup a mapped value.
         "email" => $billing_profile->uid->entity->mail->value,
         "billing_email" => $billing_profile->field_email->value,
         "first_name" => $billing_profile->field_first_name->value,
@@ -70,13 +69,15 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
         "additional_fields" => [], // @todo
       ],
       "order_total" => (float) $order->getTotalPaid()->getNumber(),
-      "items" => [],
+      "items" => [], // Set below.
     ];
 
+    // Process order items.
     foreach ($items as $item) {
       $discounts = [];
       $item_adjustments = $item->getAdjustments();
 
+      // Process discounts for this item.
       foreach ($item_adjustments as $item_adjustment) {
         $promotions = $promotion_storage->loadByProperties([
           'promotion_id' => $item_adjustment->getSourceId(),
@@ -100,6 +101,7 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
         }
       }
 
+      // Process registrations and participants for this item.
       $participants = [];
       $registrations = $registration_storage->loadByProperties([
         'commerce_order_item_id' => $item->id(),
@@ -128,7 +130,7 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
         "total" => (float) $item->getTotalPrice()->getNumber(),
         "discounted_total" => (float) $item->getAdjustedTotalPrice()->getNumber(),
         "registration" => [
-          "additional_fields" => [],
+          "additional_fields" => [], // @todo
           "description" => "",
           "product_type" => $item->bundle(),
           "course_id" => $item->getData('sf_course_id'),

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
@@ -30,6 +30,7 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
   public function getObjectForOrder(OrderInterface $order) {
     $promotion_storage = $this->entityManager->getStorage('commerce_promotion');
     $sf_mapping_storage = $this->entityManager->getStorage('salesforce_mapped_object');
+    $registration_storage = $this->entityManager->getStorage('registration');
 
     $items = $order->getItems();
     $customer = $order->getCustomer();
@@ -82,7 +83,7 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
           'promotion_id' => $item_adjustment->getSourceId(),
         ]);
 
-        if (count($promotions)) {
+        if (!empty($promotions)) {
           foreach ($promotions as $promotion) {
             $sf_promo_mapped_objects = $sf_mapping_storage->loadByEntity($promotion);
             $sf_promo_mapped_object = reset($sf_promo_mapped_objects);
@@ -101,12 +102,13 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
       }
 
       $participants = [];
-      $registration = $this->entityManager->getStorage('registration')->loadByProperties([
+      $registrations = $registration_storage->loadByProperties([
         'commerce_order_item_id' => $item->id(),
       ]);
 
-      if ($registration) {
-        $registration = reset($registration);
+      if (!empty($registrations)) {
+        $registration = reset($registrations);
+
         foreach ($registration->participants as $participant) {
           $participants[] = [
             "contact_sfid" => null,

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
@@ -71,7 +71,6 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
       ],
       "order_total" => (float) $order->getTotalPaid()->getNumber(),
       "items" => [],
-      "discounts" => [], // @todo These might be full order adjustments.
     ];
 
     foreach ($items as $item) {

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
@@ -10,8 +10,6 @@ use Drupal\commerce_order\Entity\OrderInterface;
  */
 class SerializedOrderManager implements SerializedOrderManagerInterface {
 
-  const POS_ID = 'register.ilr.cornell.edu';
-
   /**
    * Drupal\Core\Entity\EntityManagerInterface definition.
    *
@@ -48,7 +46,7 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
 
 
     $response = [
-      "point_of_sale" => $this::POS_ID,
+      "point_of_sale" => $payment_gateway->id(),
       "order_id" => $order->id(),
       "payments" => [
         [

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Drupal\ilr_registrations;
+
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\commerce_order\Entity\OrderInterface;
+
+/**
+ * Class SerializedOrderService.
+ */
+class SerializedOrderManager implements SerializedOrderManagerInterface {
+
+  const POS_ID = 'register.ilr.cornell.edu';
+
+  /**
+   * Drupal\Core\Entity\EntityManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * Constructs a new SerializedOrderService object.
+   */
+  public function __construct(EntityManagerInterface $entity_manager) {
+    $this->entityManager = $entity_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getObjectForOrder(OrderInterface $order) {
+    $promotion_storage = $this->entityManager->getStorage('commerce_promotion');
+    $sf_mapping_storage = $this->entityManager->getStorage('salesforce_mapped_object');
+
+    $items = $order->getItems();
+    $customer = $order->getCustomer();
+    $billing_profile = $order->getBillingProfile();
+    $payments = $this->entityManager->getStorage('commerce_payment')->loadByProperties([
+      'order_id' => $order->id(),
+    ]);
+    $payment = reset($payments);
+    $payment_gateway = $payment->getPaymentGateway();
+
+    // Note that this function makes a remote call to the FreedomPay API.
+    // @todo Deal with possible remote transaction retrieval failure.
+    $transaction = $payment_gateway->getPlugin()->getTransaction($payment->getRemoteId());
+
+
+    $response = [
+      "point_of_sale" => $this::POS_ID,
+      "order_id" => $order->id(),
+      "payments" => [
+        [
+          "payment_type" => $payment_gateway->getPluginId(), //"freedompay_cc",
+          "payment_id" => $payment->id(),
+          "amount" => (float) $payment->getAmount()->getNumber(),
+          "transaction_id" => $payment->getRemoteId(),
+          "transaction_data" => $transaction,
+        ]
+      ],
+      "customer" => [
+        "contact_sfid" => null,
+        "user_email" => $billing_profile->uid->entity->mail->value,
+        "billing_email" => $billing_profile->field_email->value,
+        "first_name" => $billing_profile->field_first_name->value,
+        "last_name" => $billing_profile->field_last_name->value,
+        "company" => $billing_profile->field_organization->value,
+        "job_title" => $billing_profile->field_job_title->value,
+        "phone" => $billing_profile->field_phone->value,
+        "additional_fields" => [], // @todo
+      ],
+      "order_total" => (float) $order->getTotalPaid()->getNumber(),
+      "items" => [],
+      "discounts" => [], // @todo These might be full order adjustments.
+    ];
+
+    foreach ($items as $item) {
+      $discounts = [];
+      $item_adjustments = $item->getAdjustments();
+
+      foreach ($item_adjustments as $item_adjustment) {
+        $promotions = $promotion_storage->loadByProperties([
+          'promotion_id' => $item_adjustment->getSourceId(),
+        ]);
+
+        if (count($promotions)) {
+          foreach ($promotions as $promotion) {
+            $sf_promo_mapped_objects = $sf_mapping_storage->loadByEntity($promotion);
+            $sf_promo_mapped_object = reset($sf_promo_mapped_objects);
+
+            $discount = [
+              "sfid" => $sf_promo_mapped_object->sfid(),
+              "code" => $promotion->label(),
+              "type" => $item_adjustment->getPercentage() ? 'percentage' : 'amount',
+              "amount" => (float) $item_adjustment->getAmount()->getNumber(),
+              "percentage" => (float) $item_adjustment->getPercentage(),
+            ];
+
+            $discounts[] = $discount;
+          }
+        }
+      }
+
+      $participants = [];
+      $registration = $this->entityManager->getStorage('registration')->loadByProperties([
+        'commerce_order_item_id' => $item->id(),
+      ]);
+
+      if ($registration) {
+        $registration = reset($registration);
+        foreach ($registration->participants as $participant) {
+          $participants[] = [
+            "contact_sfid" => null,
+            'email' => $participant->entity->mail->value,
+            "first_name" => $participant->entity->field_first_name->value,
+            "last_name" => $participant->entity->field_last_name->value,
+            'additional_fields' => [], // @todo
+          ];
+        }
+
+        $class_product_variation = $item->getPurchasedEntity();
+        $course_product = $class_product_variation->getProduct();
+
+        $sf_variation_mapped_objects = $sf_mapping_storage->loadByEntity($class_product_variation);
+        $sf_variation_mapped_object = reset($sf_variation_mapped_objects);
+
+        $sf_product_mapped_objects = $sf_mapping_storage->loadByEntity($course_product);
+        $sf_product_mapped_object = reset($sf_product_mapped_objects);
+      }
+
+      $response['items'][] = [
+        'name' => $item->getTitle(),
+        "discounts" => $discounts,
+        "price" => (float) $item->getUnitPrice()->getNumber(),
+        "discounted_price" => (float) $item->getAdjustedUnitPrice()->getNumber(),
+        "quantity" => (int) $item->getQuantity(),
+        "total" => (float) $item->getTotalPrice()->getNumber(),
+        "discounted_total" => (float) $item->getAdjustedTotalPrice()->getNumber(),
+        "registration" => [
+          "description" => "For example, a single course with 1+ participants.",
+          "product_type" => "Open Enrollment",
+          "course_id" => $sf_product_mapped_object->sfid(),
+          "class_id" => $sf_variation_mapped_object->sfid(),
+          "additional_fields" => [],
+          "participants" => $participants,
+        ]
+      ];
+    }
+
+    return $response;
+  }
+
+}

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
@@ -116,15 +116,6 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
             'additional_fields' => [], // @todo
           ];
         }
-
-        $class_product_variation = $item->getPurchasedEntity();
-        $course_product = $class_product_variation->getProduct();
-
-        $sf_variation_mapped_objects = $sf_mapping_storage->loadByEntity($class_product_variation);
-        $sf_variation_mapped_object = reset($sf_variation_mapped_objects);
-
-        $sf_product_mapped_objects = $sf_mapping_storage->loadByEntity($course_product);
-        $sf_product_mapped_object = reset($sf_product_mapped_objects);
       }
 
       $response['items'][] = [
@@ -138,9 +129,9 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
         "registration" => [
           "description" => "For example, a single course with 1+ participants.",
           "product_type" => "Open Enrollment",
-          "course_id" => $sf_product_mapped_object->sfid(),
-          "class_id" => $sf_variation_mapped_object->sfid(),
           "additional_fields" => [],
+          "course_id" => $item->getData('sf_course_id'),
+          "class_id" => $item->getData('sf_class_id'),
           "participants" => $participants,
         ]
       ];

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
@@ -61,7 +61,7 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
       ],
       "customer" => [
         "contact_sfid" => null,
-        "user_email" => $billing_profile->uid->entity->mail->value,
+        "email" => $billing_profile->uid->entity->mail->value,
         "billing_email" => $billing_profile->field_email->value,
         "first_name" => $billing_profile->field_first_name->value,
         "last_name" => $billing_profile->field_last_name->value,

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
@@ -128,8 +128,8 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
         "total" => (float) $item->getTotalPrice()->getNumber(),
         "discounted_total" => (float) $item->getAdjustedTotalPrice()->getNumber(),
         "registration" => [
-          "description" => "For example, a single course with 1+ participants.",
           "additional_fields" => [],
+          "description" => "",
           "product_type" => $item->bundle(),
           "course_id" => $item->getData('sf_course_id'),
           "class_id" => $item->getData('sf_class_id'),

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManager.php
@@ -129,8 +129,8 @@ class SerializedOrderManager implements SerializedOrderManagerInterface {
         "discounted_total" => (float) $item->getAdjustedTotalPrice()->getNumber(),
         "registration" => [
           "description" => "For example, a single course with 1+ participants.",
-          "product_type" => "Open Enrollment",
           "additional_fields" => [],
+          "product_type" => $item->bundle(),
           "course_id" => $item->getData('sf_course_id'),
           "class_id" => $item->getData('sf_class_id'),
           "participants" => $participants,

--- a/web/modules/custom/ilr_registrations/src/SerializedOrderManagerInterface.php
+++ b/web/modules/custom/ilr_registrations/src/SerializedOrderManagerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\ilr_registrations;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+
+/**
+ * Interface SerializedOrderManagerInterface.
+ */
+interface SerializedOrderManagerInterface {
+
+  /**
+   * Get a giant order object with lots of stuff.
+   *
+   * Stuff such as payments, discounts, customer info, mapped salesforce ids,
+   * and attached registration info.
+   *
+   * @return array An array that follows the schema from
+   * https://github.com/ilrWebServices/ilr-salesforce-bridge-api/blob/master/salesforce-webhook-request-schema.json
+   */
+  public function getObjectForOrder(OrderInterface $order);
+
+}


### PR DESCRIPTION
This adds a service that can return a PHP array that can be serialized into the JSON payload for the salesforce webhook.

It's based on the schema from https://github.com/ilrWebServices/ilr-salesforce-bridge-api/blob/master/salesforce-webhook-request-schema.json with the following changes:

- Added customer `billing_email` because that can be different than `email`.
- Renamed `payment` to `payments` and it's now an array, because orders can have multiple partial payments in commerce.
- Added `transaction_data` to payments, replacing the `authorization_code`, `card_type`, and `masked_card_number` items. This allows for multiple payments of different types. The `transaction_data` field for `freedompay_hpp` payment types will be an entire data dump from FreedomPay. The replaced fields can be found at the following locations in `transaction_data`:
    - `authorization_code`: `AuthResponse.FreewayResponse.AuthorizationCode`
    - `card_type`: `CardIssuer`
    - `masked_card_number`: `MaskedCardNumber`
- Added `name` to `items`.
- Added `quantity` and `discount_total` to `items`.
- Renamed _item_ `discount` to `discounts` and it's now an array, because items can have multiple discounts in commerce.
- Item discount `amount` is now always a dollar amount, and there is a new `percentage` item that is either null, for fixed amount discounts, or a decimal, for percent off discounts.
- Renamed `discount_code` to `code`.
- Renamed `discount_type` to `type`.

To test:

There is a temporary, NON-AUTHENTICATED, endpoint for any given order at `/admin/commerce/orders/{commerce_order}/serialized`.  So on my setup, I can visit something like http://registrations.ilr.test/admin/commerce/orders/1/serialized for order number 1.